### PR TITLE
Add configurable API endpoint and week numbering TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,6 @@ You can see the api schema by hitting  `/openapi.yaml`
 - Does not factor in women's only or age 65+ lane times
 - Some indoor pools are labelled as outdoor if they have both
  (i.e. Giovani Caboto on Saint Claire)
-
+ 
+ ### Run in the background
+ `nohup uvicorn get_pools:app --host 127.0.0.1 --port 3000 > pools.log 2>&1 &`

--- a/TODOS.md
+++ b/TODOS.md
@@ -62,9 +62,33 @@ Each pool object already contains a `website` field with Toronto's facility page
 
 ---
 
+## Data Accuracy Issues
+
+### 5. Fix week numbering inconsistency in Toronto API
+**Priority**: High
+**Effort**: Medium
+
+Currently we assume week1.json = current week and week2.json = next week, but Toronto's API doesn't always follow this pattern. Some pools may have different week numbering or date ranges.
+
+**Issues**:
+- Week1 might not always be the current calendar week
+- Some pools may have different scheduling periods
+- Date ranges in the API response should be validated against actual calendar dates
+
+**Solution approaches**:
+- Parse the actual date ranges from the API response data
+- Validate dates against current calendar week before processing
+- Add date range detection to determine which week file contains current/future dates
+- Consider fetching multiple week files and filtering by actual dates
+- Add logging to track when week numbering doesn't match expectations
+
+**Current logic**: `scrape.py:181` assumes `[(1, 0), (2, 1)]` where week1=current, week2=next
+
+---
+
 ## Technical Debt
 
-### 5. Update FastAPI event handlers
+### 6. Update FastAPI event handlers
 **Priority**: Low
 **Effort**: Low
 

--- a/index.html
+++ b/index.html
@@ -343,7 +343,8 @@
                     pools: [],
                     loading: false,
                     error: null,
-                    searched: false
+                    searched: false,
+                    apiBaseUrl: this.getApiBaseUrl()
                 };
             },
             mounted() {
@@ -375,6 +376,18 @@
                 }
             },
             methods: {
+                getApiBaseUrl() {
+                    // Detect if running locally (file:// or localhost/127.0.0.1)
+                    const isLocal = window.location.protocol === 'file:' ||
+                                  window.location.hostname === 'localhost' ||
+                                  window.location.hostname === '127.0.0.1' ||
+                                  window.location.hostname === '';
+
+                    return isLocal
+                        ? 'http://127.0.0.1:3000'
+                        : 'https://www.connorladly.com/api/toronto-pools';
+                },
+
                 async searchPools() {
                     if (!this.startDate || !this.endDate) {
                         this.error = 'Please select both start and end dates';
@@ -390,7 +403,7 @@
                         const endParam = this.formatDateForAPI(this.endDate);
 
                         const response = await fetch(
-                            `http://127.0.0.1:3000/pools?start_date=${startParam}&end_date=${endParam}&simple=true`
+                            `${this.apiBaseUrl}/pools?start_date=${startParam}&end_date=${endParam}&simple=true`
                         );
 
                         if (!response.ok) {


### PR DESCRIPTION
- Make frontend API endpoint configurable for local vs production environments
- Auto-detect environment and use appropriate API base URL
- Add high-priority TODO for week numbering inconsistency in Toronto API
- Add deployment instructions for background service

🤖 Generated with [Claude Code](https://claude.ai/code)