### PR TITLE
Fix mobile pool info spacing and height issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,14 +83,15 @@
             .pool-row {
                 flex-direction: column;
                 align-items: flex-start;
-                padding: 16px;
+                padding: 12px;
             }
 
             .pool-info {
-                flex: none;
+                flex: 0 0 auto !important;
                 margin-right: 0;
-                margin-bottom: 6px;
+                margin-bottom: 8px;
                 width: 100%;
+                height: auto;
             }
 
             .time-slots {
@@ -114,6 +115,18 @@
 
             .pool-actions {
                 gap: 4px;
+            }
+
+            .pool-name {
+                margin-bottom: 1px;
+            }
+
+            .pool-address {
+                margin-bottom: 2px;
+            }
+
+            .pool-distance {
+                margin-bottom: 2px;
             }
         }
 


### PR DESCRIPTION
- Fix hardcoded 280px height by overriding flex with !important
- Reduce pool row padding from 16px to 12px on mobile
- Add mobile-specific margin reductions for pool info elements:
  - pool-name: 2px → 1px margin-bottom
  - pool-address: 4px → 2px margin-bottom
  - pool-distance: 4px → 2px margin-bottom
- Set optimal 8px gap between directions and swim times
- Add explicit height: auto for proper mobile sizing

Creates compact, readable mobile layout without excessive spacing.

🤖 Generated with [Claude Code](https://claude.ai/code)