### PR TITLE
Fix sitemap URLs to use correct domain path

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://laneduck.com/</loc>
+    <loc>https://www.connorladly.com/lane-duck/</loc>
     <lastmod>2025-10-05</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://laneduck.com/openapi.yaml</loc>
+    <loc>https://www.connorladly.com/lane-duck/openapi.yaml</loc>
     <lastmod>2025-10-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.3</priority>


### PR DESCRIPTION
## Summary
• Fixed sitemap URLs to use correct domain path instead of incorrect domain
• Updated URLs from laneduck.com to www.connorladly.com/lane-duck/
• Ensures sitemap reflects actual deployment location for proper SEO indexing

## Changes Made
- **Fixed homepage URL**: `https://laneduck.com/` → `https://www.connorladly.com/lane-duck/`
- **Fixed API docs URL**: `https://laneduck.com/openapi.yaml` → `https://www.connorladly.com/lane-duck/openapi.yaml`
- URLs now match actual deployment path structure

## Impact
- Search engines will now correctly index the actual site location
- Sitemap accurately reflects where the application is hosted
- Fixes potential SEO issues from incorrect URL mapping
- Ready for submission to Google Search Console with correct URLs

## Technical Details
- Sitemap follows XML schema standards with corrected URLs
- Both homepage and API documentation endpoints use proper paths
- URLs are production-ready and match deployment structure

🤖 Generated with [Claude Code](https://claude.ai/code)