### PR TITLE
Include venue-named and quiet lane swims (fixes Giovanni Caboto showing none)

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -153,6 +153,21 @@ def convert_to_new_format(obj, week_offset=0, swim_type_title=None):
     }
 
 
+# Lane-swim titles that are demographic/age-restricted and intentionally NOT
+# counted as general lane swims (matches the app's existing scope: no women's-only,
+# men's-only, or 65+ sessions).
+EXCLUDED_LANE_SWIM_QUALIFIERS = ('(women)', '(men)', 'older adult', 'adapted')
+
+def is_general_lane_swim(title: str) -> bool:
+    """True for open lane-swim sessions. Accepts plain "Lane Swim", course
+    variants ("... Long Course (50m)"), venue-named variants
+    ("Lane Swim (Giovanni Caboto)") and "Quiet (No Music)"; excludes the
+    demographic/age-restricted variants above."""
+    if not title or not title.startswith('Lane Swim'):
+        return False
+    lowered = title.lower()
+    return not any(q in lowered for q in EXCLUDED_LANE_SWIM_QUALIFIERS)
+
 def process_swim_data(raw_swim_data: dict, week_offset=0) -> dict:
     swim_data_objs = [program["days"] for program in raw_swim_data['programs'] if program['program'] == 'Swim - Drop-In']
     if len(swim_data_objs) == 0:
@@ -162,7 +177,7 @@ def process_swim_data(raw_swim_data: dict, week_offset=0) -> dict:
     swim_data_objs = swim_data_objs[0]
     flattened_swim_sessions = []
     for swim_data_obj in swim_data_objs:
-        if swim_data_obj['title'] in {'Lane Swim', 'Lane Swim: Long Course (50m)', 'Lane Swim: Short Course (25m)'} and swim_data_obj['status'] == 'active':
+        if is_general_lane_swim(swim_data_obj['title']) and swim_data_obj['status'] == 'active':
             filtered_sessions = [session for session in swim_data_obj['times'] if session['status'] == 'active']
             swim_type_title = swim_data_obj['title']
             flattened_swim_sessions.extend([convert_to_new_format(session, week_offset, swim_type_title) for session in filtered_sessions])


### PR DESCRIPTION
## Problem
Found while verifying local pools on the live site: **Giovanni Caboto Outdoor Pool showed zero lane swims, but Toronto's feed has 26 active lane swims** for it this window. The scraper's title matcher only accepted three exact strings:

```
{'Lane Swim', 'Lane Swim: Long Course (50m)', 'Lane Swim: Short Course (25m)'}
```

So venue-named variants (`Lane Swim (Giovanni Caboto)`) and other general variants (`Lane Swim: Quiet (No Music)`, `Lane Swim: Family`) were silently dropped across the whole system.

## Fix
Replaces the exact-title allowlist with `is_general_lane_swim(title)`: accepts any title starting with `Lane Swim` **except** demographic/age-restricted qualifiers — `(women)`, `(men)`, `older adult`, `adapted`. This preserves the app's existing scope (no women's-only / men's-only / 65+ sessions) while stopping general lane swims from being lost just because of a venue name or "quiet" tag.

## Verification (pre-deploy)
- Unit test over the real title variants: all pass (accepts Caboto/Quiet/Family/course/plain; rejects Men/Women/Older Adult/Adapted/Leisure).
- Ran the real extraction on Giovanni Caboto (id 514): **0 → 26 sessions**, matching the source feed.

Post-merge this needs `./deploy.sh` + a server scrape to take effect (server cache regenerates with the newly-included sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
