### PR TITLE
Remove pool-length filter, badges, and legend from UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,25 +313,10 @@
             outline-offset: 2px;
         }
 
-        /* Active length chips take on their length color so the filter doubles
-           as a color key for the time-slots below. */
         .chip.active {
             color: #fff;
             border-color: transparent;
             box-shadow: 0 2px 6px rgba(0,0,0,0.15);
-        }
-
-        .chip.active.chip-25m {
-            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-        }
-
-        .chip.active.chip-50m {
-            background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
-            color: #1C2B2A;
-        }
-
-        .chip.active.chip-unknown {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         }
 
         .chip.active.chip-type {
@@ -473,24 +458,6 @@
             min-width: 140px;
         }
 
-        .time-slot.length-25m,
-        .time-slot.length-25y {
-            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-        }
-
-        .time-slot.length-50m,
-        .time-slot.length-50y {
-            /* Pink/yellow gradient is light at the yellow end, so use dark ink
-               text here for legibility (white fails contrast). */
-            background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
-            color: #1C2B2A;
-        }
-
-        .time-slot.length-50m .pool-length,
-        .time-slot.length-50y .pool-length {
-            background: rgba(0, 0, 0, 0.12);
-        }
-
         .time-range {
             font-weight: 600;
             font-size: 0.9rem;
@@ -500,17 +467,6 @@
             font-size: 0.75rem;
             opacity: 0.8;
             margin-top: 2px;
-        }
-
-        .pool-length {
-            display: inline-block;
-            margin-top: 4px;
-            background: rgba(255, 255, 255, 0.25);
-            padding: 1px 6px;
-            border-radius: 3px;
-            font-size: 0.62rem;
-            font-weight: 600;
-            letter-spacing: 0.02em;
         }
 
         .no-results {
@@ -583,24 +539,6 @@
                 </div>
 
                 <div class="filter-row-secondary">
-                    <div class="chip-group" role="group" aria-label="Filter by pool length">
-                        <label>Length: {{ selectedLengths.length ? selectedLengths.map(lengthLabel).join(', ') : 'Any' }}</label>
-                        <div class="chips">
-                            <button type="button" class="chip chip-25m"
-                                    :class="{ active: selectedLengths.includes('25') }"
-                                    :aria-pressed="selectedLengths.includes('25')"
-                                    @click="toggleLength('25')">25m</button>
-                            <button type="button" class="chip chip-50m"
-                                    :class="{ active: selectedLengths.includes('50') }"
-                                    :aria-pressed="selectedLengths.includes('50')"
-                                    @click="toggleLength('50')">50m</button>
-                            <button type="button" class="chip chip-unknown"
-                                    :class="{ active: selectedLengths.includes('unknown') }"
-                                    :aria-pressed="selectedLengths.includes('unknown')"
-                                    @click="toggleLength('unknown')">Unknown</button>
-                        </div>
-                    </div>
-
                     <div class="chip-group" role="group" aria-label="Filter by pool type">
                         <label>Type: {{ selectedTypes.length ? selectedTypes.join(', ') : 'All' }}</label>
                         <div class="chips">
@@ -632,22 +570,6 @@
                         <span class="results-count" aria-live="polite">{{ filteredPools.length }} pools found</span>
                     </div>
 
-                    <div class="pool-legend" style="margin-bottom: 20px; display: flex; gap: 15px; align-items: center; font-size: 0.9rem;">
-                        <span style="font-weight: 600;">Pool Lengths:</span>
-                        <div style="display: flex; align-items: center; gap: 5px;">
-                            <div style="width: 16px; height: 16px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border-radius: 4px;"></div>
-                            <span>Unknown Length</span>
-                        </div>
-                        <div style="display: flex; align-items: center; gap: 5px;">
-                            <div style="width: 16px; height: 16px; background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); border-radius: 4px;"></div>
-                            <span>25m Short Course</span>
-                        </div>
-                        <div style="display: flex; align-items: center; gap: 5px;">
-                            <div style="width: 16px; height: 16px; background: linear-gradient(135deg, #fa709a 0%, #fee140 100%); border-radius: 4px;"></div>
-                            <span>50m Long Course</span>
-                        </div>
-                    </div>
-
                     <div class="pool-table">
                         <div class="pool-row" v-for="pool in filteredPools" :key="pool.pool_name">
                             <div class="pool-info">
@@ -668,17 +590,13 @@
                             </div>
                             <div class="time-slots">
                                 <div class="time-slot"
-                                     :class="'length-' + (time.pool_length || 'unknown').toLowerCase()"
                                      v-for="time in pool.times"
-                                     :key="time.start_time + '-' + (time.pool_length || 'u')">
+                                     :key="time.start_time">
                                     <div class="time-range">
                                         {{ formatTime(time.start_time) }} - {{ formatTime(time.end_time) }}
                                     </div>
                                     <div class="time-date">
                                         {{ formatDate(time.start_time) }}
-                                    </div>
-                                    <div class="pool-length">
-                                        {{ time.pool_length && time.pool_length !== 'Unknown' ? time.pool_length : 'Length N/A' }}
                                     </div>
                                 </div>
                             </div>
@@ -687,9 +605,9 @@
                 </div>
 
                 <div v-if="!loading && pools.length > 0 && filteredPools.length === 0" class="no-results">
-                    <h3>No pools match these filters</h3>
-                    <p>No lane swims match your selected length/type in this time range.</p>
-                    <button class="clear-filter-btn" @click="clearChipFilters">Show all lengths &amp; types</button>
+                    <h3>No pools match this filter</h3>
+                    <p>No {{ selectedTypes.join('/') }} pools have lane swims in this time range.</p>
+                    <button class="clear-filter-btn" @click="clearChipFilters">Show all pools</button>
                 </div>
 
                 <div v-if="!loading && searched && pools.length === 0" class="no-results">
@@ -722,25 +640,15 @@
                     locationPermission: 'unknown', // 'unknown', 'granted', 'denied'
                     sortByDistance: false,
                     locationLoading: false,
-                    selectedLengths: [], // buckets: '25', '50', 'unknown' (empty = Any)
                     selectedTypes: []    // 'Indoor', 'Outdoor' (empty = All)
                 };
             },
             computed: {
                 filteredPools() {
-                    return this.pools
-                        // Type filter: whole-pool. Empty selection = all types.
-                        .filter(pool => this.selectedTypes.length === 0 || this.selectedTypes.includes(pool.pool_type))
-                        // Length filter: slot-level. Empty selection = any length.
-                        .map(pool => {
-                            if (this.selectedLengths.length === 0) return pool;
-                            const times = (pool.times || []).filter(
-                                t => this.selectedLengths.includes(this.lengthBucket(t.pool_length))
-                            );
-                            return { ...pool, times };
-                        })
-                        // Drop pools left with no matching slots.
-                        .filter(pool => pool.times && pool.times.length > 0);
+                    // Type filter: whole-pool. Empty selection = all types.
+                    return this.pools.filter(
+                        pool => this.selectedTypes.length === 0 || this.selectedTypes.includes(pool.pool_type)
+                    );
                 }
             },
             mounted() {
@@ -900,9 +808,7 @@
                         if (savedPref && this.userLocation) {
                             this.sortByDistance = true;
                         }
-                        const savedLengths = localStorage.getItem('laneduck_selectedLengths');
                         const savedTypes = localStorage.getItem('laneduck_selectedTypes');
-                        if (savedLengths) this.selectedLengths = JSON.parse(savedLengths);
                         if (savedTypes) this.selectedTypes = JSON.parse(savedTypes);
                     } catch (e) {
                         // Corrupt/blocked storage — fall back to defaults silently.
@@ -922,35 +828,10 @@
 
                 saveChipFilters() {
                     try {
-                        localStorage.setItem('laneduck_selectedLengths', JSON.stringify(this.selectedLengths));
                         localStorage.setItem('laneduck_selectedTypes', JSON.stringify(this.selectedTypes));
                     } catch (e) {
                         // Storage unavailable — non-fatal.
                     }
-                },
-
-                lengthBucket(poolLength) {
-                    // Collapse metric/yard lengths into a distance bucket: 25m/25y -> '25',
-                    // 50m/50y -> '50', everything else -> 'unknown'.
-                    if (!poolLength) return 'unknown';
-                    const match = String(poolLength).match(/^(\d+)/);
-                    if (match && match[1] === '25') return '25';
-                    if (match && match[1] === '50') return '50';
-                    return 'unknown';
-                },
-
-                lengthLabel(bucket) {
-                    return { '25': '25m', '50': '50m', 'unknown': 'Unknown' }[bucket] || bucket;
-                },
-
-                toggleLength(bucket) {
-                    const i = this.selectedLengths.indexOf(bucket);
-                    if (i === -1) {
-                        this.selectedLengths.push(bucket);
-                    } else {
-                        this.selectedLengths.splice(i, 1);
-                    }
-                    this.saveChipFilters();
                 },
 
                 toggleType(type) {
@@ -964,7 +845,6 @@
                 },
 
                 clearChipFilters() {
-                    this.selectedLengths = [];
                     this.selectedTypes = [];
                     this.saveChipFilters();
                 },


### PR DESCRIPTION
Length data is unhelpful: Toronto exposes a length for well under 1% of lane swims, so nearly every slot showed "Length N/A." This removes the length filter chips, per-slot length badge, length-based colour coding, and the legend. The Indoor/Outdoor filter (and its persistence) is unchanged; time slots now use one consistent colour.

Verified headless: only Indoor/Outdoor chips remain, no badge/legend, 83 pools render, type filter works, zero JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)