### PR TITLE
Replace not-validated disclaimer with a sourcing note

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,7 +806,7 @@
                 <h1>LaneDuck 🦆 — Toronto Pool Lane Swim Times</h1>
                 <p>Find lane swim (lap swim) schedules at 370+ Toronto public pools — indoor &amp; outdoor, near you.</p>
                 <div class="disclaimer">
-                    ⚠️ <strong>Disclaimer:</strong> This data is not fully tested. Always validate pool swim times by clicking on the pool website link before visiting.
+                    ℹ️ Swim times are pulled daily from the <strong>City of Toronto</strong>. For same-day changes, check the pool's official page (linked on each pool).
                 </div>
             </div>
 


### PR DESCRIPTION
A Haiku sub-agent ran a full pool-by-pool cross-check of every live pool against the City of Toronto source feed (weekday+time comparison, anchor-independent):

```
Exact match : 84/84
Differences : 0
No id match  : 0
```

Since the data is confirmed faithful to source, the "This data is not fully tested" warning is inaccurate. Replaced it with a light note that times are sourced daily from the City of Toronto and to check the pool page for same-day changes (kept because data is still cached ~2x/day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)