### PR TITLE
Anchor scrape/prerender dates to America/Toronto (fixes empty Today view)

### DIFF
--- a/prerender.py
+++ b/prerender.py
@@ -36,7 +36,13 @@ def build(cache_file=CACHE_FILE, output_file=OUTPUT_FILE):
     with open(cache_file, "r", encoding="utf-8") as f:
         pools = json.load(f)
 
-    now = datetime.now()
+    # Toronto wall-clock time (naive) so "already finished" is judged in the
+    # pools' local timezone, matching the naive datetimes stored in the cache.
+    try:
+        from scrape import now_toronto
+        now = now_toronto().replace(tzinfo=None)
+    except Exception:
+        now = datetime.now()
     pools = sorted(pools, key=lambda p: p.get("complexname", ""))
 
     pool_sections = []

--- a/scrape.py
+++ b/scrape.py
@@ -90,6 +90,21 @@ def fetch_with_retries(url, max_retries=3, backoff_factor=2):
 
 from datetime import datetime, timedelta
 
+
+def now_toronto():
+    """Current date/time in Toronto. The pools and users are all in Toronto, so
+    the "current week" must be anchored to Toronto's calendar, not the server's
+    UTC clock — otherwise, when the server (UTC) crosses midnight into a new week
+    before Toronto does (e.g. Sunday ~8pm-midnight ET), the scraper drops the day
+    users still consider "today" and the site shows no pools for it."""
+    try:
+        import pytz
+        return datetime.now(pytz.timezone("America/Toronto"))
+    except Exception:
+        # Fallback: naive local time (fine for local dev machines set to ET).
+        return datetime.now()
+
+
 def convert_to_new_format(obj, week_offset=0, swim_type_title=None):
     """
     Converts the input dictionary into the specified format.
@@ -113,8 +128,8 @@ def convert_to_new_format(obj, week_offset=0, swim_type_title=None):
         "sunday": 6
     }
 
-    # Get the current date and calculate the start of the week (Monday)
-    today = datetime.now()
+    # Get the current date (Toronto time) and calculate the start of the week (Monday)
+    today = now_toronto()
     start_of_week = today - timedelta(days=today.weekday())  # Monday of the current week
 
     # Add week offset for next week data


### PR DESCRIPTION
The default Today view showed No pools found on Sunday evenings. Root cause: scrape.py anchored the current week to the server UTC clock, so once UTC crossed into Monday (8pm ET Sunday) the scraper dropped Sunday, which Toronto users were still on.

Fix: now_toronto() (pytz America/Toronto, naive fallback) anchors the week in convert_to_new_format and the finished-session filter in prerender.py. Output stays naive ISO; only the anchor date changes.

Verified on the UTC server: pytz -> Sun Jul 5 (week includes today), naive UTC -> Mon Jul 6 (dropped it). pytz 2019.3 is present on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)