### PR TITLE
Harden timezone handling; add requirements.txt, scrape sanity check + monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy this to `.env` on the server (it is gitignored — never commit real values).
+# Both get_pools.py (API) and scrape.py load it automatically via obs.load_dotenv(),
+# so cron and PM2 both pick these up without extra config.
+
+# Sentry DSN for error reporting (API endpoints + daily scrape). Empty = disabled.
+SENTRY_DSN=
+
+# Healthchecks.io ping URL for the daily scrape. On success the scraper pings this
+# URL; on failure (or a failed content sanity check) it pings <url>/fail. Empty = disabled.
+HC_SCRAPE_PING_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/*
 *.zip
 logs/*
 pool_schedules.html
+.env

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,7 +37,7 @@ echo -e "${YELLOW}📦 Step 1: Uploading assets to server...${NC}"
 
 # Upload Python files
 echo "Uploading Python backend files..."
-gcloud compute scp get_pools.py scrape.py prerender.py "$SERVER:$REMOTE_DIR/" \
+gcloud compute scp get_pools.py scrape.py prerender.py obs.py "$SERVER:$REMOTE_DIR/" \
     --zone "$ZONE" --project "$PROJECT"
 
 # Upload frontend
@@ -52,7 +52,7 @@ gcloud compute scp README.md CLAUDE.md TODOS.md "$SERVER:$REMOTE_DIR/" \
 
 # Upload configuration files
 echo "Uploading configuration files..."
-gcloud compute scp .gitignore openapi.yaml sitemap.xml og-image.png "$SERVER:$REMOTE_DIR/" \
+gcloud compute scp .gitignore openapi.yaml sitemap.xml og-image.png requirements.txt .env.example "$SERVER:$REMOTE_DIR/" \
     --zone "$ZONE" --project "$PROJECT"
 
 echo -e "${GREEN}✅ Assets uploaded successfully${NC}"

--- a/get_pools.py
+++ b/get_pools.py
@@ -43,6 +43,13 @@ import json
 import os
 import yaml
 
+# Observability: load secrets from .env and start Sentry if configured.
+# No-op (never raises) when SENTRY_DSN is unset or sentry_sdk is not installed,
+# so the API keeps running regardless.
+import obs
+obs.load_dotenv()
+obs.init_sentry(environment="production")
+
 app = FastAPI()
 
 # Add CORS middleware to allow browser requests

--- a/obs.py
+++ b/obs.py
@@ -1,0 +1,79 @@
+"""Lightweight observability helpers: .env loading, optional Sentry, and
+Healthchecks.io pings. Everything degrades to a clean no-op when a piece is
+absent (no DSN, sentry_sdk not installed, no ping URL), so monitoring can never
+break the app or the scrape.
+
+Secrets are read from the environment only — populate a gitignored
+`.env` next to this file (KEY=VALUE lines) on the server; never commit them.
+"""
+import os
+
+
+def load_dotenv(path=None):
+    """Load KEY=VALUE lines from a local .env into os.environ without overriding
+    variables already set in the real environment. Silent if the file is missing.
+    Lets cron and PM2 pick up secrets from one file."""
+    path = path or os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                key = key.strip()
+                val = val.strip().strip('"').strip("'")
+                if key:
+                    os.environ.setdefault(key, val)
+    except FileNotFoundError:
+        pass
+    except Exception:
+        # A malformed .env must never crash startup.
+        pass
+
+
+def init_sentry(environment="production"):
+    """Initialize Sentry if SENTRY_DSN is set and sentry_sdk is installed.
+    Returns True if enabled, False otherwise. Never raises."""
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        return False
+    try:
+        import sentry_sdk
+        sentry_sdk.init(dsn=dsn, traces_sample_rate=0.1, environment=environment)
+        return True
+    except Exception:
+        return False
+
+
+def capture_exception(exc):
+    """Report an exception to Sentry if available; no-op otherwise."""
+    try:
+        import sentry_sdk
+        sentry_sdk.capture_exception(exc)
+    except Exception:
+        pass
+
+
+def capture_message(message, level="error"):
+    """Report a message to Sentry if available; no-op otherwise."""
+    try:
+        import sentry_sdk
+        sentry_sdk.capture_message(message, level=level)
+    except Exception:
+        pass
+
+
+def ping_healthchecks(success=True):
+    """Ping the Healthchecks.io URL in HC_SCRAPE_PING_URL. On failure, append
+    /fail so a silent-but-wrong scrape still raises an alert. Never raises and
+    never blocks (short timeout)."""
+    url = os.environ.get("HC_SCRAPE_PING_URL")
+    if not url:
+        return
+    try:
+        import requests
+        target = url if success else url.rstrip("/") + "/fail"
+        requests.get(target, timeout=10)
+    except Exception:
+        pass

--- a/prerender.py
+++ b/prerender.py
@@ -38,11 +38,9 @@ def build(cache_file=CACHE_FILE, output_file=OUTPUT_FILE):
 
     # Toronto wall-clock time (naive) so "already finished" is judged in the
     # pools' local timezone, matching the naive datetimes stored in the cache.
-    try:
-        from scrape import now_toronto
-        now = now_toronto().replace(tzinfo=None)
-    except Exception:
-        now = datetime.now()
+    # Uses the same fail-loud Toronto clock as the scraper (no silent UTC).
+    from scrape import now_toronto
+    now = now_toronto().replace(tzinfo=None)
     pools = sorted(pools, key=lambda p: p.get("complexname", ""))
 
     pool_sections = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Pinned to the versions currently running on the production VM (connorladly-1)
+# so the environment is reproducible. Install with: pip3 install -r requirements.txt
+fastapi==0.115.12
+uvicorn==0.33.0
+requests==2.22.0
+PyYAML==5.3.1
+tqdm==4.67.1
+pytz==2019.3
+
+# Observability (optional at runtime — the app no-ops if SENTRY_DSN is unset).
+sentry-sdk[fastapi]>=2.0,<3

--- a/scrape.py
+++ b/scrape.py
@@ -96,13 +96,13 @@ def now_toronto():
     the "current week" must be anchored to Toronto's calendar, not the server's
     UTC clock — otherwise, when the server (UTC) crosses midnight into a new week
     before Toronto does (e.g. Sunday ~8pm-midnight ET), the scraper drops the day
-    users still consider "today" and the site shows no pools for it."""
-    try:
-        import pytz
-        return datetime.now(pytz.timezone("America/Toronto"))
-    except Exception:
-        # Fallback: naive local time (fine for local dev machines set to ET).
-        return datetime.now()
+    users still consider "today" and the site shows no pools for it.
+
+    Deliberately does NOT fall back to naive UTC on error: silently using the
+    wrong timezone reintroduces that exact bug with no signal. pytz is pinned in
+    requirements.txt, so a missing/broken tz database should fail loudly instead."""
+    import pytz  # required dependency; see requirements.txt
+    return datetime.now(pytz.timezone("America/Toronto"))
 
 
 def convert_to_new_format(obj, week_offset=0, swim_type_title=None):
@@ -308,6 +308,23 @@ def log_scrape_completion():
 
     logger.info(f"Scrape completion logged to {log_file}")
 
+def sanity_check_current_day(pool_data):
+    """Guard against the wrong-week bug: the cache must cover today (Toronto).
+    Returns (ok, message). ok=False means the current week was likely dropped
+    (earliest session is in the future), which is exactly the "no pools today"
+    failure — something a plain success/heartbeat cannot detect."""
+    today = now_toronto().date().isoformat()
+    dates = [s.get("start_time", "")[:10]
+             for p in pool_data for s in p.get("swim_data", [])
+             if s.get("start_time")]
+    if not dates:
+        return False, "cache contains zero sessions"
+    earliest, latest = min(dates), max(dates)
+    today_count = dates.count(today)
+    ok = earliest <= today
+    return ok, (f"today={today} sessions_today={today_count} "
+                f"earliest={earliest} latest={latest} covers_today={ok}")
+
 def main():
     logger.info("Fetching fresh data from Toronto API...")
 
@@ -345,5 +362,31 @@ def main():
     # Log completion timestamp
     log_scrape_completion()
 
+    # Content sanity check: the cache must cover today (Toronto). Catches the
+    # wrong-week bug that a plain heartbeat would miss (scrape "succeeds" but
+    # drops the current week).
+    ok, msg = sanity_check_current_day(pool_data)
+    if ok:
+        logger.info(f"Sanity check passed: {msg}")
+    else:
+        logger.error(f"Sanity check FAILED: {msg}")
+    return ok
+
 if __name__ == "__main__":
-    main()
+    import sys
+    import obs
+    obs.load_dotenv()
+    obs.init_sentry(environment="production")
+    try:
+        scrape_ok = main()
+    except Exception as e:
+        obs.capture_exception(e)
+        obs.ping_healthchecks(success=False)
+        raise
+    obs.ping_healthchecks(success=bool(scrape_ok))
+    if not scrape_ok:
+        obs.capture_message(
+            "Scrape sanity check failed: cache does not cover today (Toronto)",
+            level="error",
+        )
+        sys.exit(1)


### PR DESCRIPTION
Implements the review recommendations, corrected for the VM (Python 3.8, so stdlib zoneinfo is unavailable — pytz stays).

### 1. Fail-loud timezone
- now_toronto() no longer silently falls back to UTC (that silent fallback would reintroduce the no-pools-today bug undetected). pytz is required + pinned; a missing tz db raises. prerender uses the same clock.

### 2. requirements.txt
- Pins the versions actually running on the VM + sentry-sdk. There was none before.

### 3. Content sanity check + heartbeat
- After each scrape, assert the cache covers **today (Toronto)**. This catches wrong-week data that a plain heartbeat cannot (the scrape still succeeds). On failure -> Healthchecks /fail + exit 1 + Sentry message.

### Monitoring plumbing (obs.py)
- Optional Sentry init (FastAPI integration in get_pools.py) + Healthchecks ping in scrape.py, both read from env and **degrade to no-ops** when unset or sentry_sdk absent — never breaks the app or scrape.
- Secrets load from a gitignored .env (see .env.example): SENTRY_DSN, HC_SCRAPE_PING_URL. Nothing hardcoded; cron and PM2 both pick it up.

Verified: all files compile, API boots clean with obs, now_toronto returns America/Toronto, sanity check passes on real cache, monitoring no-ops without secrets.

**Post-merge you must set on the VM:** create ~/lane-duck/.env with SENTRY_DSN and HC_SCRAPE_PING_URL (I will not handle secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)