### PR TITLE
Replace pytz with zoneinfo (backports shim on Python 3.8)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,12 @@ uvicorn==0.33.0
 requests==2.22.0
 PyYAML==5.3.1
 tqdm==4.67.1
-pytz==2019.3
+
+# Timezone handling. now_toronto() uses stdlib zoneinfo (Python 3.9+) or the
+# backports.zoneinfo shim on the VM's Python 3.8; tzdata ships the IANA database
+# as a wheel so the correct tz data is present regardless of the OS.
+tzdata==2026.3
+backports.zoneinfo==0.2.1; python_version < "3.9"
 
 # Observability (optional at runtime — the app no-ops if SENTRY_DSN is unset).
 sentry-sdk[fastapi]>=2.0,<3

--- a/scrape.py
+++ b/scrape.py
@@ -98,11 +98,18 @@ def now_toronto():
     before Toronto does (e.g. Sunday ~8pm-midnight ET), the scraper drops the day
     users still consider "today" and the site shows no pools for it.
 
+    Uses the stdlib zoneinfo (Python 3.9+), or the backports.zoneinfo shim on the
+    VM's Python 3.8. The tzdata pip package is pinned in requirements.txt so the
+    IANA database is guaranteed present regardless of the OS.
+
     Deliberately does NOT fall back to naive UTC on error: silently using the
-    wrong timezone reintroduces that exact bug with no signal. pytz is pinned in
-    requirements.txt, so a missing/broken tz database should fail loudly instead."""
-    import pytz  # required dependency; see requirements.txt
-    return datetime.now(pytz.timezone("America/Toronto"))
+    wrong timezone reintroduces that exact bug with no signal. A missing tz
+    database therefore raises loudly (ZoneInfoNotFoundError) instead."""
+    try:
+        from zoneinfo import ZoneInfo          # Python 3.9+
+    except ImportError:                          # Python 3.8 (production VM)
+        from backports.zoneinfo import ZoneInfo  # provided by backports.zoneinfo
+    return datetime.now(ZoneInfo("America/Toronto"))
 
 
 def convert_to_new_format(obj, week_offset=0, swim_type_title=None):

--- a/test_week_anchor.py
+++ b/test_week_anchor.py
@@ -15,15 +15,18 @@ import unittest
 from datetime import datetime
 from unittest.mock import patch
 
-import pytz
+try:
+    from zoneinfo import ZoneInfo          # Python 3.9+
+except ImportError:                          # Python 3.8
+    from backports.zoneinfo import ZoneInfo
 
 import scrape
 
-TORONTO = pytz.timezone("America/Toronto")
+TORONTO = ZoneInfo("America/Toronto")
 
 # Sunday 2026-07-12, 8:30pm Toronto time. At this instant UTC is already
 # Monday 2026-07-13 00:30 — the exact condition that triggered the bug.
-SUNDAY_EVENING_ET = TORONTO.localize(datetime(2026, 7, 12, 20, 30))
+SUNDAY_EVENING_ET = datetime(2026, 7, 12, 20, 30, tzinfo=TORONTO)
 
 # The current week (Mon..Sun) that must appear in the output.
 EXPECTED = {


### PR DESCRIPTION
## Why
The Toronto clock previously used `pytz` (2019.3, effectively unmaintained). This moves to the standard-library `zoneinfo` API — the outcome originally wanted — without breaking the VM's **Python 3.8**, which has no stdlib `zoneinfo`.

## How
`now_toronto()` imports `zoneinfo.ZoneInfo` on Python 3.9+ and `backports.zoneinfo.ZoneInfo` on 3.8. The `tzdata` wheel is pinned so the IANA database is guaranteed present regardless of what the OS ships. It stays **fail-loud**: a missing tz database raises `ZoneInfoNotFoundError` rather than silently falling back to naive UTC (which is exactly the wrong-week / "no pools today" bug).

- `requirements.txt`: `pytz==2019.3` → `tzdata==2026.3` + `backports.zoneinfo==0.2.1; python_version < "3.9"`
- `test_week_anchor.py`: builds the Sunday-evening Toronto instant via `ZoneInfo(...)` instead of `pytz.localize(...)`

## Verified
- On the VM (Py 3.8.10): installed `backports.zoneinfo` 0.2.1 + `tzdata` 2026.3; `scrape.now_toronto()` → `2026-07-12 …-04:00` (correct EDT).
- Locally (Py 3.13, stdlib path): `test_week_anchor.py` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
