### PR TITLE
Fix blank beaches page + FAQ corrections + beach SEO snapshot + length fixes

### DIFF
--- a/beaches.html
+++ b/beaches.html
@@ -25,9 +25,9 @@
     <meta property="og:url" content="https://www.connorladly.com/lane-duck/beaches">
     <meta property="og:image" content="https://www.connorladly.com/lane-duck/og-image.png">
 
-    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+    <!-- Leaflet stylesheet in head; the Vue + Leaflet scripts load at end of body
+         so a slow/flaky CDN can never leave the page blank (they no longer block paint). -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <style>
         :root {
             --bg-1: #e8f3f2; --bg-2: #d6e9ea; --surface: #ffffff; --surface-2: #f5f8f8;
@@ -104,6 +104,13 @@
         .loading, .empty { text-align: center; color: var(--text-muted); padding: 40px 16px; }
         .foot { margin-top: 26px; text-align: center; color: var(--text-faint); font-size: .82rem; }
         .foot a { color: var(--accent-strong); }
+        .beach-static { margin-top: 30px; padding-top: 20px; border-top: 1px solid var(--border); color: var(--text-muted); font-size: .9rem; }
+        .beach-static h2 { font-size: 1.15rem; color: var(--text); margin-bottom: 10px; }
+        .beach-static ul { list-style: none; display: grid; gap: 6px; margin-top: 8px; }
+        .beach-static a { color: var(--accent-strong); font-weight: 600; }
+        .bs-safe { color: var(--safe-fg); font-weight: 700; }
+        .bs-unsafe { color: var(--unsafe-fg); font-weight: 700; }
+        .bs-unknown { color: var(--unknown-fg); font-weight: 700; }
         .leaflet-popup-content { font-size: .88rem; line-height: 1.45; }
         .leaflet-popup-content a { color: #12766f; font-weight: 700; }
         @media (max-width: 600px) { #beachMap { height: 360px; } .view-toggle { margin-left: 0; } }
@@ -168,6 +175,20 @@
         </p>
     </div>
 
+    <!-- Static, crawlable snapshot of current beach conditions. Populated by
+         prerender.py on each scrape; also the fallback shown if the app can't load. -->
+    <section class="beach-static wrap" aria-labelledby="beach-static-h">
+        <h2 id="beach-static-h">Toronto beach water quality — today's conditions</h2>
+        <!-- BEACHES_STATIC_START -->
+        <p>Live SAFE / UNSAFE swim advisories for Toronto's supervised beaches load above.
+           Water quality is sampled daily in summer by Toronto Public Health. If the interactive
+           version doesn't load, see the
+           <a href="https://www.toronto.ca/community-people/health-wellness-care/health-inspections-monitoring/swimsafe/beach-water-quality/">City of Toronto beach water quality page</a>.</p>
+        <!-- BEACHES_STATIC_END -->
+    </section>
+
+    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
         const { createApp } = Vue;
         createApp({

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
             "Filter indoor and outdoor pools",
             "Sort pools by distance from your location",
             "One-tap directions to each pool",
-            "25m and 50m lane lengths"
+            "25y, 25m, 50y and 50m lane lengths"
           ],
           "author": {
             "@type": "Person",
@@ -101,7 +101,7 @@
               "name": "Are Toronto public pool lane swims free?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Yes. Drop-in lane swimming at City of Toronto public pools is free — no registration or membership required. Just arrive during a scheduled lane swim."
+                "text": "It depends on the pool. Outdoor pool lane swims are free — just show up during a scheduled lane swim. Indoor pool lane swims usually require a paid drop-in admission (or a membership/pass). Check the pool's official page for its fees."
               }
             },
             {
@@ -125,7 +125,7 @@
               "name": "What pool lengths are available?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Toronto pools offer 25-metre and 50-metre lanes. Longer 50m lanes are ideal for continuous lap swimming."
+                "text": "Toronto pools come in several lengths — 25 yards (25y), 25 metres (25m), 50 yards (50y) and 50 metres (50m). LaneDuck labels each pool's length where known so you can filter for the distance you want."
               }
             },
             {
@@ -150,10 +150,9 @@
     }
     </script>
 
-    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
-    <!-- Leaflet (map view) -->
+    <!-- Leaflet stylesheet in head; Vue + Leaflet scripts load at end of body so a
+         slow/flaky CDN never blocks first paint (prevents blank/frozen page). -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <style>
         :root {
             --bg-1: #e8f3f2;
@@ -1112,13 +1111,13 @@
             </ol>
 
             <h2>Toronto pools and neighbourhoods covered</h2>
-            <p>LaneDuck covers indoor and outdoor public pools across all six Toronto districts — <strong>Downtown / Old Toronto, East York, Etobicoke, North York, Scarborough and York</strong> — with 25-metre and 50-metre lanes. Whether you want an early-morning lap swim downtown or an evening swim in the suburbs, you can check today's lane swim schedule in seconds.</p>
+            <p>LaneDuck covers indoor and outdoor public pools across all six Toronto districts — <strong>Downtown / Old Toronto, East York, Etobicoke, North York, Scarborough and York</strong> — with pools in 25 yards, 25 metres, 50 yards and 50 metres. Whether you want an early-morning lap swim downtown or an evening swim in the suburbs, you can check today's lane swim schedule in seconds.</p>
             <p><a href="/lane-duck/pools"><strong>Browse the full lane swim schedule for every Toronto pool →</strong></a> — a complete, printable list of every pool with lane swimming, its address, and upcoming times.</p>
 
             <h2>Frequently asked questions</h2>
             <div class="faq-item">
                 <h3>Are Toronto public pool lane swims free?</h3>
-                <p>Yes. Drop-in lane swimming at City of Toronto public pools is free — no registration or membership required. Just arrive during a scheduled lane swim.</p>
+                <p>It depends on the pool. <strong>Outdoor</strong> pool lane swims are free — just show up during a scheduled lane swim. <strong>Indoor</strong> pool lane swims usually require a paid drop-in admission (or a membership/pass). Check the pool's official page for its fees.</p>
             </div>
             <div class="faq-item">
                 <h3>How many Toronto pools offer lane swimming?</h3>
@@ -1130,7 +1129,7 @@
             </div>
             <div class="faq-item">
                 <h3>What pool lengths are available?</h3>
-                <p>Toronto pools offer 25-metre and 50-metre lanes. Longer 50m lanes are ideal for continuous lap swimming.</p>
+                <p>Toronto pools come in several lengths — 25 yards (25y), 25 metres (25m), 50 yards (50y) and 50 metres (50m). LaneDuck labels each pool's length where known so you can filter for the distance you want.</p>
             </div>
             <div class="faq-item">
                 <h3>How often are the swim schedules updated?</h3>
@@ -1145,6 +1144,8 @@
         </div>
     </section>
 
+    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
         const { createApp } = Vue;
 

--- a/pool_lengths.json
+++ b/pool_lengths.json
@@ -253,9 +253,9 @@
   },
   "425": {
     "name": "Leaside Outdoor Pool",
-    "length": "25m",
-    "confidence": "medium",
-    "source": "places2swim"
+    "length": "unknown",
+    "confidence": "low",
+    "source": "audit: units unconfirmed / non-standard length"
   },
   "678": {
     "name": "Ledbury Park",
@@ -409,9 +409,9 @@
   },
   "433": {
     "name": "Sunnyside Gus Ryder Outdoor Pool",
-    "length": "25m",
-    "confidence": "medium",
-    "source": "toronto.ca"
+    "length": "unknown",
+    "confidence": "low",
+    "source": "audit: units unconfirmed / non-standard length"
   },
   "282": {
     "name": "Swansea Community Recreation Centre",

--- a/prerender.py
+++ b/prerender.py
@@ -54,6 +54,68 @@ def stamp_sitemap(sitemap_file="sitemap.xml"):
     return today
 
 
+def build_beaches(cache_file="tmp/beaches_cache.json", html_file="beaches.html"):
+    """Inject a static, crawlable snapshot of current beach conditions into
+    beaches.html (between the BEACHES_STATIC markers). Gives search engines real
+    content and doubles as the fallback shown if the interactive app can't load.
+    Fully non-fatal: missing cache/markers/file just skips."""
+    START, END = "<!-- BEACHES_STATIC_START -->", "<!-- BEACHES_STATIC_END -->"
+    try:
+        with open(cache_file, "r", encoding="utf-8") as f:
+            beaches = json.load(f)
+        with open(html_file, "r", encoding="utf-8") as f:
+            page = f.read()
+    except (FileNotFoundError, ValueError) as e:
+        print(f"build_beaches: skipped ({e})")
+        return None
+    if START not in page or END not in page or not beaches:
+        print("build_beaches: markers missing or no beaches, skipped")
+        return None
+
+    def status_span(s):
+        cls = {"SAFE": "bs-safe", "UNSAFE": "bs-unsafe"}.get(s, "bs-unknown")
+        label = {"SAFE": "🟢 Safe to swim", "UNSAFE": "🔴 Unsafe"}.get(s, "⚪ No recent data")
+        return f'<span class="{cls}">{label}</span>'
+
+    def fmt_date(iso):
+        try:
+            return datetime.strptime(iso, "%Y-%m-%d").strftime("%B %-d")
+        except (ValueError, TypeError):
+            return iso or "n/a"
+
+    dates = [b.get("sample_date") for b in beaches if b.get("sample_date")]
+    latest = fmt_date(max(dates)) if dates else "the latest sampling day"
+    safe = sum(1 for b in beaches if b.get("status") == "SAFE")
+    unsafe = sum(1 for b in beaches if b.get("status") == "UNSAFE")
+
+    items = []
+    for b in sorted(beaches, key=lambda x: x.get("beach_name", "")):
+        name = html.escape(b.get("beach_name", "").strip())
+        eco = b.get("ecoli")
+        bits = []
+        if eco is not None:
+            bits.append(f"E. coli {html.escape(str(eco))}")
+        if b.get("sample_date"):
+            bits.append(f"sampled {fmt_date(b['sample_date'])}")
+        if b.get("blue_flag"):
+            bits.append("Blue Flag")
+        detail = f" ({', '.join(bits)})" if bits else ""
+        items.append(f"      <li>{status_span(b.get('status'))} — <strong>{name}</strong>{detail}</li>")
+
+    snapshot = (
+        f"\n        <p>As of {latest}, {len(beaches)} Toronto supervised beaches are monitored for water quality — "
+        f"{safe} currently safe to swim{f', {unsafe} posted unsafe' if unsafe else ''}. "
+        f"Toronto Public Health samples E. coli daily in summer; a beach is posted unsafe above 100 E. coli/100 mL.</p>\n"
+        f"    <ul>\n{os.linesep.join(items)}\n    </ul>\n    "
+    )
+
+    new_page = page[:page.index(START) + len(START)] + snapshot + page[page.index(END):]
+    with open(html_file, "w", encoding="utf-8") as f:
+        f.write(new_page)
+    print(f"build_beaches: wrote snapshot for {len(beaches)} beaches ({safe} safe, {unsafe} unsafe)")
+    return html_file
+
+
 def build(cache_file=CACHE_FILE, output_file=OUTPUT_FILE):
     with open(cache_file, "r", encoding="utf-8") as f:
         pools = json.load(f)

--- a/scrape.py
+++ b/scrape.py
@@ -410,6 +410,8 @@ def main():
     try:
         import beaches
         beaches.build()
+        import prerender
+        prerender.build_beaches()  # static crawlable snapshot into beaches.html
     except Exception as e:
         logger.error(f"Beaches refresh failed (non-fatal): {e}")
 


### PR DESCRIPTION
Addresses two live issues the user hit, plus follow-ups.

## 1. Blank/frozen beaches page (root cause + fix)
`beaches.html` put **all** content inside the Vue `#app` while loading Vue + Leaflet as **render-blocking scripts in `<head>`** from unpkg. When the CDN was slow/flaky, the page stayed white until they loaded. (Confirmed: with the Vue CDN blocked, the old beaches page had nothing outside `#app`, while the pools page still showed its `.seo-content`.)

**Fix:** moved Vue + Leaflet scripts to end of `<body>` (no longer block first paint) on both `beaches.html` and `index.html`, and added a static, crawlable beach snapshot **outside `#app`** that also serves as the no-JS / failed-CDN fallback. Populated by `prerender.build_beaches()` each scrape (also good SEO).

## 2. FAQ corrections (JSON-LD + visible copy)
- Free/paid: outdoor pool lane swims are free; indoor usually require a paid drop-in admission (was "all free").
- Pool lengths: now lists 25y / 25m / 50y / 50m (was only 25m/50m); also updated featureList + about text.

## 3. Length fixes
Leaside Outdoor Pool and Sunnyside Gus Ryder to unknown (audit couldn't confirm units / non-standard 91x21 m pool).

## Testing
Headless: beaches page renders cards + static section normally; with the Vue CDN blocked it shows header + fallback content (not blank). Main map still shows pool + beach markers, no JS errors. build_beaches populates the snapshot; FAQ JSON-LD valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
