### PR TITLE
Fix beaches nav links to absolute /lane-duck paths

### DIFF
--- a/beaches.html
+++ b/beaches.html
@@ -121,7 +121,7 @@
     <div id="app" class="wrap">
         <header class="hero">
             <h1>🌊 Toronto Beach Water Quality</h1>
-            <p>Is it safe to swim today? Daily E. coli advisories for Toronto's supervised beaches. <a href="./">← Pool lane swim finder</a></p>
+            <p>Is it safe to swim today? Daily E. coli advisories for Toronto's supervised beaches. <a href="/lane-duck">← Pool lane swim finder</a></p>
         </header>
 
         <div class="notice" v-if="anyStale">

--- a/index.html
+++ b/index.html
@@ -886,7 +886,7 @@
                 <div class="disclaimer">
                     ℹ️ Swim times are pulled daily from the <strong>City of Toronto</strong>. For same-day changes, check the pool's official page (linked on each pool).
                 </div>
-                <a class="beaches-link" href="./beaches">🌊 Open water? Check Toronto beach water quality →</a>
+                <a class="beaches-link" href="/lane-duck/beaches">🌊 Open water? Check Toronto beach water quality →</a>
             </div>
 
             <div class="filters">


### PR DESCRIPTION
The page is served at `/lane-duck` (no trailing slash), so `href="./beaches"` resolved to `/beaches`. Switched the cross-link and back-link to absolute `/lane-duck/beaches` and `/lane-duck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)